### PR TITLE
Undead Legacy Compatibility

### DIFF
--- a/Config/entityclasses.ulm.xml
+++ b/Config/entityclasses.ulm.xml
@@ -1,3 +1,7 @@
+<config>
+	
 	<append xpath="/entity_classes/entity_class[@name='vehicleLawnMower']">
 		    <property name="Consumables" value="ulmAmmoFuelGasoline,ulmAmmoFuelGasolineBarrel"/>
 	</append>
+
+</configs>

--- a/Config/entityclasses.ulm.xml
+++ b/Config/entityclasses.ulm.xml
@@ -1,0 +1,3 @@
+	<append xpath="/entity_classes/entity_class[@name='vehicleLawnMower']">
+		    <property name="Consumables" value="ulmAmmoFuelGasoline,ulmAmmoFuelGasolineBarrel"/>
+	</append>

--- a/Config/entityclasses.xml
+++ b/Config/entityclasses.xml
@@ -25,4 +25,8 @@
 
 	</append>
 
+	<modif condition="UndeadLegacy_CoreModule">
+		<include path="entityclasses.ulm.xml"/>
+	</modif>
+	
 </configs>

--- a/Config/items.ulm.xml
+++ b/Config/items.ulm.xml
@@ -1,0 +1,8 @@
+<configs>
+
+<!-- Using the Cargo Capacity of the Quad as an inital reference. -->
+<append xpath="/items/item[@name='vehicleLawnMowerPlaceable']/effect_group[@name='vehicleLawnMowerPlaceable']">
+			<passive_effect name="VehicleCargoCapacity" operation="base_set" value="700"/>
+</append>
+
+</configs>

--- a/Config/items.xml
+++ b/Config/items.xml
@@ -7,5 +7,9 @@
 	<modelse>
 		<include path="items.a20.xml"/>
 	</modelse>
-
+	<modif condition="UndeadLegacy_CoreModule">
+		<include path="items.ulm.xml"/>
+	</modif>
+	
+	
 </configs>

--- a/Config/items.xml
+++ b/Config/items.xml
@@ -11,5 +11,4 @@
 		<include path="items.ulm.xml"/>
 	</modif>
 	
-	
 </configs>


### PR DESCRIPTION
Undead Legacy uses different items for fuel storage and requires vehicles to have a cargo capacity.