### PR TITLE
Refresh mower materials before light updates

### DIFF
--- a/.github/workflows/material-cache-contract.yml
+++ b/.github/workflows/material-cache-contract.yml
@@ -1,0 +1,20 @@
+name: material-cache-contract
+
+on:
+  pull_request:
+    paths:
+      - Library/VPMower.cs
+      - tests/test_material_cache_contract.py
+      - .github/workflows/material-cache-contract.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate material cache refresh contract
+        run: python3 -m unittest -v tests/test_material_cache_contract.py

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.pdb
 /node_modules
 /package*.json*
+__pycache__/
+*.pyc

--- a/Library/VPMower.cs
+++ b/Library/VPMower.cs
@@ -127,13 +127,13 @@ public class VPMower : VehiclePart
 
         if (vehicle == null) return;
 
-        // Collect all materials (in a unique fashion)
-        Transform transform = vehicle.GetMeshTransform();
-        foreach (var renderer in transform?.GetComponentsInChildren<Renderer>(true))
-            if (!Materials.Contains(renderer.material)) Materials.Add(renderer.material);
+        RefreshMaterials();
         // Reset brake lights on initialization
         foreach (var material in Materials)
+        {
+            if (material == null) continue;
             material.SetVector("_BrakeColor", Color.black);
+        }
         // Collect `MowerHarvestTags` from all modifiers
         foreach (ItemValue mod in modifications)
         {
@@ -327,10 +327,7 @@ public class VPMower : VehiclePart
     {
         if (vehicle == null) return;
         if (IsBroken()) state = false;
-        Transform transform = vehicle.GetMeshTransform();
-        if (transform == null) return; // Play safe in case of bad data
-        foreach (var renderer in transform?.GetComponentsInChildren<Renderer>(true))
-            if (!Materials.Contains(renderer.material)) Materials.Add(renderer.material);
+        RefreshMaterials();
         foreach (var material in Materials)
         {
             if (material == null) continue;
@@ -340,6 +337,19 @@ public class VPMower : VehiclePart
             var color = IsOn ? ColorMowerOn : Color.black;
             material.SetColor("_MowerOnColor", color);
         }
+    }
+
+    // ####################################################################
+    // ####################################################################
+
+    private void RefreshMaterials()
+    {
+        if (vehicle == null) return;
+        Transform transform = vehicle.GetMeshTransform();
+        if (transform == null) return; // Play safe in case of bad data
+        foreach (var renderer in transform.GetComponentsInChildren<Renderer>(true))
+            if (renderer != null && renderer.material != null && !Materials.Contains(renderer.material))
+                Materials.Add(renderer.material);
     }
 
     // ####################################################################
@@ -361,6 +371,7 @@ public class VPMower : VehiclePart
         // Update material if state changed
         if (HasBrakes != LastBrakes)
         {
+            RefreshMaterials();
             Color color = ColorBrakeLight * HasBrakes * 0.5f;
             foreach (var material in Materials)
             {

--- a/Library/VPMower.cs
+++ b/Library/VPMower.cs
@@ -348,8 +348,12 @@ public class VPMower : VehiclePart
         Transform transform = vehicle.GetMeshTransform();
         if (transform == null) return; // Play safe in case of bad data
         foreach (var renderer in transform.GetComponentsInChildren<Renderer>(true))
-            if (renderer != null && renderer.material != null && !Materials.Contains(renderer.material))
-                Materials.Add(renderer.material);
+        {
+            if (renderer == null) continue;
+            Material material = renderer.material;
+            if (material != null && !Materials.Contains(material))
+                Materials.Add(material);
+        }
     }
 
     // ####################################################################

--- a/tests/test_material_cache_contract.py
+++ b/tests/test_material_cache_contract.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+import re
+import unittest
+
+
+SOURCE = (Path(__file__).resolve().parents[1] / "Library/VPMower.cs").read_text()
+
+
+def method_body(name: str) -> str:
+    match = re.search(
+        rf"\b{name}\([^)]*\)\s*\{{",
+        SOURCE,
+    )
+    if match is None:
+        raise AssertionError(f"method not found: {name}")
+
+    depth = 1
+    cursor = match.end()
+    while cursor < len(SOURCE) and depth:
+        if SOURCE[cursor] == "{":
+            depth += 1
+        elif SOURCE[cursor] == "}":
+            depth -= 1
+        cursor += 1
+    return SOURCE[match.end() : cursor - 1]
+
+
+class MaterialCacheContractTests(unittest.TestCase):
+    def test_emission_refreshes_materials_before_iteration(self) -> None:
+        body = method_body("ToggleEmission")
+        self.assertLess(body.index("RefreshMaterials();"), body.index("foreach"))
+
+    def test_brake_transition_refreshes_materials_before_iteration(self) -> None:
+        body = method_body("Update")
+        transition = body[body.index("if (HasBrakes != LastBrakes)") :]
+        self.assertLess(
+            transition.index("RefreshMaterials();"),
+            transition.index("foreach"),
+        )
+
+    def test_material_accessor_is_captured_once_per_renderer(self) -> None:
+        body = method_body("RefreshMaterials")
+        self.assertIn("Material material = renderer.material;", body)
+        self.assertEqual(body.count("renderer.material"), 1)
+        self.assertIn("material != null", body)
+        self.assertIn("!Materials.Contains(material)", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- refreshes the lawn tractor material cache before mower/headlight emission updates
- refreshes the cache before brake-light transitions, covering F6/spawned vehicles without a mod/dye change
- captures Unity's `renderer.material` accessor once per renderer and filters null/duplicate materials
- preserves existing modification-time cache behavior

## Validation
- focused material-cache contract: 3 passed
- actionlint: passed
- independent exact-head review: no actionable defects
- exact upstream PR head: `2145c72bf0617ad7fe987668573ea76d5f084be1`
- exact-head CI: https://github.com/lancer1977/OcbLawnMowing/actions/runs/30194864428
- fork adoption PR: https://github.com/lancer1977/OcbLawnMowing/pull/4
- fork merge SHA: `8884e4cc1cc854af3e743335e77990a2ac6db05c`

The full game assembly remains dependent on the upstream Windows 7D2D compiler/toolchain. No in-game validation is claimed.

Advances #6.